### PR TITLE
sleepypid: Prometheus endpoint, drop-in metric prefix, seasonal full-voltage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+**/__pycache__
+*.pyc
+sleepypi
+*.service
+LICENSE
+README.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/arduino-test.yml
+++ b/.github/workflows/arduino-test.yml
@@ -11,7 +11,7 @@ jobs:
           sudo apt-get update && sudo apt-get -qyf install wget unzip python3-dev
           pip3 install -r requirements.txt
           PYTHONPATH=sleepypid ./sleepypid/test_sleepypid.py
-          wget -O/tmp/ide.zip https://downloads.arduino.cc/arduino-ide/arduino-ide_2.1.0_Linux_64bit.zip
+          wget -O/tmp/ide.zip https://downloads.arduino.cc/arduino-ide/arduino-ide_2.3.2_Linux_64bit.zip
           unzip /tmp/ide.zip
           find arduino-ide* -name python3 -exec ln -sf $(which python3) {} \;
           mkdir ~/bin

--- a/.github/workflows/arduino-test.yml
+++ b/.github/workflows/arduino-test.yml
@@ -5,12 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
       - name: Install
         run: |
-          sudo apt-get update && sudo apt-get -qyf install wget unzip python3-dev
-          pip3 install -r requirements.txt
-          PYTHONPATH=sleepypid ./sleepypid/test_sleepypid.py
+          sudo apt-get update && sudo apt-get -qyf install wget unzip
           wget -O/tmp/ide.zip https://downloads.arduino.cc/arduino-ide/arduino-ide_2.3.2_Linux_64bit.zip
           unzip /tmp/ide.zip
           find arduino-ide* -name python3 -exec ln -sf $(which python3) {} \;

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,12 @@
+name: python-test
+on: [push, pull_request]
+jobs:
+  docker-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and test in Docker
+        run: docker build --target test -t sleepypid-test .
+      - name: Build runtime image
+        run: docker build --target runtime -t sleepypid .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim AS base
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY sleepypid/ ./sleepypid/
+
+# Build/test stage: `docker build --target test` fails if tests or lint fail.
+FROM base AS test
+RUN pip install --no-cache-dir pylint pytest
+RUN PYTHONPATH=sleepypid pylint --fail-under=8 sleepypid/sleepypid.py
+RUN PYTHONPATH=sleepypid python sleepypid/test_sleepypid.py
+
+# Runtime stage: the sleepypid daemon. Exposes Prometheus metrics on 9110.
+FROM base AS runtime
+EXPOSE 9110
+ENTRYPOINT ["python", "sleepypid/sleepypid.py"]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,26 @@
 8. In the IDE, on the opened `sleepypi.ino` file, first "Verify" (check mark icon), and assuming that succeeds, proceed to "Upload" (right arrow icon)
 9. You should see JSON info coming in on the serial monitor and the board should start blinking
 10. Pull USB cables, remove programming board, and deploy your freshly flashed SleepyPi
+
+# sleepypid daemon
+
+`sleepypid/sleepypid.py` polls the SleepyPi hat over serial, manages sleep/wake
+duty cycling, and logs telemetry.
+
+## Prometheus metrics
+
+By default the daemon exposes its current sensor values and derived state as
+Prometheus gauges on port `9110` (override with `--prometheus-port`, disable
+with `--no-prometheus`). Point a Prometheus scrape at `http://<host>:9110/metrics`
+instead of parsing the log file. All metrics are prefixed `sleepypi_`, e.g.
+`sleepypi_mean1mSupplyVoltage`, `sleepypi_mean1mRpiCurrent`, `sleepypi_soc`,
+`sleepypi_powerState`, and `sleepypi_cputempc`.
+
+## Running the tests
+
+Tests and lint run inside Docker:
+
+```
+docker build --target test .
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+prometheus_client
 pyserial

--- a/sleepypid/sleepypid.py
+++ b/sleepypid/sleepypid.py
@@ -23,6 +23,7 @@ MEAN_V = 'mean1mSupplyVoltage'
 MEAN_C = 'mean1mRpiCurrent'
 SHUTDOWN_TIMEOUT = 60
 PROMETHEUS_PREFIX = 'sleepypi_'
+prometheus_prefix = PROMETHEUS_PREFIX
 prometheus_gauges = {}
 
 
@@ -152,7 +153,7 @@ def log_prometheus(prometheus, obj):
         gauge = prometheus_gauges.get(key)
         if gauge is None:
             gauge = Gauge(
-                "%s%s" % (PROMETHEUS_PREFIX, key),
+                "%s%s" % (prometheus_prefix, key),
                 "sleepypi telemetry %s" % key)
             prometheus_gauges[key] = gauge
         gauge.set(value)
@@ -297,6 +298,9 @@ def parse_args():
     parser.add_argument(
         '--prometheus-port', default=9110, type=int,
         help='port to expose Prometheus metrics on')
+    parser.add_argument(
+        '--prometheus-prefix', default=PROMETHEUS_PREFIX,
+        help='prefix for exported Prometheus metric names (set empty for bare names)')
     parser.add_argument('--prometheus', dest='prometheus', action='store_true')
     parser.add_argument('--no-prometheus', dest='prometheus', action='store_false')
     parser.set_defaults(prometheus=True)
@@ -320,6 +324,7 @@ if __name__ == '__main__':
     main_args = parse_args()
     main_args = override_args(main_args)
     if main_args.prometheus:
+        prometheus_prefix = main_args.prometheus_prefix
         start_http_server(main_args.prometheus_port)
     if main_args.startscript:
         call_script(main_args.startscript)

--- a/sleepypid/sleepypid.py
+++ b/sleepypid/sleepypid.py
@@ -8,7 +8,6 @@ import datetime
 import json
 import platform
 import random
-import socket
 import statistics
 import subprocess
 import sys
@@ -16,13 +15,15 @@ import time
 import os
 from collections import defaultdict
 import serial
+from prometheus_client import Gauge, start_http_server
 
 MIN_SLEEP_MINS = 15
 MAX_SLEEP_MINS = (6 * 60) - MIN_SLEEP_MINS
 MEAN_V = 'mean1mSupplyVoltage'
 MEAN_C = 'mean1mRpiCurrent'
 SHUTDOWN_TIMEOUT = 60
-sensor_data = {}
+PROMETHEUS_PREFIX = 'sleepypi_'
+prometheus_gauges = {}
 
 
 class SerialException(Exception):
@@ -84,7 +85,7 @@ def send_command(command, args):
         summary['response'] = json.loads(response_bytes.decode())
         command_error = summary['response'].get('error', None)
 
-    log_json(args.log, args.grafana, args.grafana_path, summary)
+    log_json(args.log, summary, args.prometheus)
     return (summary, command_error)
 
 
@@ -120,47 +121,44 @@ def configure_sleepypi(args):
                 sys.exit(-1)
 
 
-def log_grafana(grafana, grafana_path, obj, write_results):
-    """Log grafana telemetry."""
-    global sensor_data
+def flatten_telemetry(obj):
+    """Flatten a nested telemetry object into scalar key/value pairs."""
+    flat = copy.copy(obj)
+    if "loadavg" in flat:
+        m1, m5, m15 = flat.pop("loadavg")
+        flat["loadavg1m"] = m1
+        flat["loadavg5m"] = m5
+        flat["loadavg15m"] = m15
+    response = flat.get("response")
+    if isinstance(response, dict) and response.get("command") == "sensors":
+        for key, value in response.items():
+            flat[key] = value
+        del flat["response"]
+    if "window_diffs" in flat:
+        for key, value in flat.pop("window_diffs").items():
+            flat[key + "_window_diffs"] = value
+    return flat
 
-    if not grafana:
+
+def log_prometheus(prometheus, obj):
+    """Update Prometheus gauges from a telemetry object."""
+    if not prometheus:
         return
-    grafana_obj = copy.copy(obj)
-    timestamp = int(time.time()*1000)
-    if "loadavg" in grafana_obj:
-        loadavg = grafana_obj["loadavg"]
-        del grafana_obj["loadavg"]
-        m1, m5, m15 = loadavg
-        grafana_obj["loadavg1m"] = m1
-        grafana_obj["loadavg5m"] = m5
-        grafana_obj["loadavg15m"] = m15
-    if ("response" in grafana_obj and
-            "command" in grafana_obj["response"] and
-            grafana_obj["response"]["command"] == "sensors"):
-        for key in grafana_obj["response"]:
-            grafana_obj[key] = grafana_obj["response"][key]
-        del grafana_obj["response"]
-    if "window_diffs" in grafana_obj:
-        for key in grafana_obj["window_diffs"]:
-            grafana_obj[key+"_window_diffs"] = grafana_obj["window_diffs"][key]
-        del grafana_obj["window_diffs"]
-    for key in grafana_obj.keys():
-        if key in sensor_data:
-            sensor_data[key].append([grafana_obj[key], timestamp])
-        else:
-            sensor_data[key] = [[grafana_obj[key], timestamp]]
-    if write_results:
-        hostname = socket.gethostname()
-        os.makedirs(grafana_path, exist_ok=True)
-        with open(f'{grafana_path}/{hostname}-{timestamp}-sleepypi.json', 'w', encoding='utf-8') as f:
-            for k, v in sensor_data.items():
-                record = {"target": k, "datapoints": v}
-                f.write(f'{json.dumps(record)}\n')
-        sensor_data = {}
+    for key, value in flatten_telemetry(obj).items():
+        if isinstance(value, bool):
+            value = int(value)
+        elif not isinstance(value, (int, float)):
+            continue
+        gauge = prometheus_gauges.get(key)
+        if gauge is None:
+            gauge = Gauge(
+                "%s%s" % (PROMETHEUS_PREFIX, key),
+                "sleepypi telemetry %s" % key)
+            prometheus_gauges[key] = gauge
+        gauge.set(value)
 
 
-def log_json(log, grafana, grafana_path, obj, rollover=900, iterations=0):
+def log_json(log, obj, prometheus=True):
     """Log JSON object."""
 
     if os.path.isdir(log):
@@ -182,11 +180,7 @@ def log_json(log, grafana, grafana_path, obj, rollover=900, iterations=0):
     with open(log_path, 'a', encoding='utf-8') as logfile:
         logfile.write(json.dumps(obj) + '\n')
 
-    write_results = False
-    # wait for a rollover or a snooze command to write out results
-    if (iterations != 0 and iterations % rollover == 0) or ('command' in obj and 'command' in obj['command'] and 'snooze' in obj['command']['command']):
-        write_results = True
-    log_grafana(grafana, grafana_path, obj, write_results)
+    log_prometheus(prometheus, obj)
 
 
 def calc_soc(mean_v, args):
@@ -237,13 +231,12 @@ def loop(args):
                         'window_diffs': window_diffs,
                         'soc': soc,
                     }
-                    log_json(args.log, args.grafana, args.grafana_path, window_summary, args.window_samples*60, args.polltime*ticker)
+                    log_json(args.log, window_summary, args.prometheus)
 
                     if args.sleepscript and (sample_count % args.window_samples == 0):
                         duration = sleep_duty_seconds(soc, args.minsleepmins, args.maxsleepmins)
                         if duration:
                             send_command({'command': 'snooze', 'duration': duration}, args)
-                            log_grafana(args.grafana, args.grafana_path, window_summary, True)
                             call_script(args.sleepscript)
                             sys.exit(0)
 
@@ -299,14 +292,14 @@ def parse_args():
     parser.add_argument('--startscript', default='',
         help='script to run on startup')
     parser.add_argument(
-        '--grafana-path', default='/flash/telemetry/sensors',
-        help='directory to write out JSON files for Grafana, only enabled if Grafana is enabled')
-    parser.add_argument(
         '--argjson', default='',
         help='file with JSON to override arguments')
-    parser.add_argument('--grafana', dest='grafana', action='store_true')
-    parser.add_argument('--no-grafana', dest='grafana', action='store_false')
-    parser.set_defaults(grafana=True)
+    parser.add_argument(
+        '--prometheus-port', default=9110, type=int,
+        help='port to expose Prometheus metrics on')
+    parser.add_argument('--prometheus', dest='prometheus', action='store_true')
+    parser.add_argument('--no-prometheus', dest='prometheus', action='store_false')
+    parser.set_defaults(prometheus=True)
     main_args = parser.parse_args()
     assert main_args.shutdownvoltage > main_args.deepsleepvoltage
     assert main_args.fullvoltage > main_args.shutdownvoltage
@@ -326,6 +319,8 @@ def override_args(main_args):
 if __name__ == '__main__':
     main_args = parse_args()
     main_args = override_args(main_args)
+    if main_args.prometheus:
+        start_http_server(main_args.prometheus_port)
     if main_args.startscript:
         call_script(main_args.startscript)
     configure_sleepypi(main_args)

--- a/sleepypid/sleepypid.py
+++ b/sleepypid/sleepypid.py
@@ -6,6 +6,7 @@ import argparse
 import copy
 import datetime
 import json
+import math
 import platform
 import random
 import statistics
@@ -184,14 +185,51 @@ def log_json(log, obj, prometheus=True):
     log_prometheus(prometheus, obj)
 
 
-def calc_soc(mean_v, args):
+def daylength_hours(day_of_year, latitude):
+    """Daylight hours for a day-of-year and latitude (Forsythe et al. 1995)."""
+    lat = math.radians(latitude)
+    theta = 0.2163108 + 2 * math.atan(
+        0.9671396 * math.tan(0.00860 * (day_of_year - 186)))
+    phi = math.asin(0.39795 * math.cos(theta))
+    p = 0.8333  # sun's apparent radius + refraction at sunrise/sunset
+    arg = ((math.sin(math.radians(p)) + math.sin(lat) * math.sin(phi)) /
+           (math.cos(lat) * math.cos(phi)))
+    arg = max(-1.0, min(1.0, arg))
+    return 24.0 - (24.0 / math.pi) * math.acos(arg)
+
+
+def seasonal_fullvoltage(args, when=None):
+    """Full-charge voltage scaled by photoperiod.
+
+    With args.winter_fullvoltage set, args.fullvoltage is the lightest-day
+    (summer) value and winter_fullvoltage the darkest-day value. The threshold
+    is interpolated by today's daylength between the local solstices: less light
+    -> higher threshold -> the battery reads as less full -> the Pi sleeps more.
+    Returns the static args.fullvoltage when winter_fullvoltage is unset.
+    """
+    winter = getattr(args, 'winter_fullvoltage', 0)
+    if not winter:
+        return args.fullvoltage
+    latitude = getattr(args, 'latitude', 0)
+    when = when or datetime.date.today()
+    daylengths = [daylength_hours(d, latitude) for d in range(1, 366)]
+    dmin, dmax = min(daylengths), max(daylengths)
+    today = daylength_hours(when.timetuple().tm_yday, latitude)
+    light = (today - dmin) / (dmax - dmin) if dmax > dmin else 1.0
+    light = max(0.0, min(1.0, light))
+    return winter + light * (args.fullvoltage - winter)
+
+
+def calc_soc(mean_v, args, fullvoltage=None):
     """Calculate battery SOC."""
     # TODO: consider discharge current.
-    if mean_v >= args.fullvoltage:
+    if fullvoltage is None:
+        fullvoltage = args.fullvoltage
+    if mean_v >= fullvoltage:
         return 100
     if mean_v <= args.shutdownvoltage:
         return 0
-    return (mean_v - args.shutdownvoltage) / (args.fullvoltage - args.shutdownvoltage) * 100
+    return (mean_v - args.shutdownvoltage) / (fullvoltage - args.shutdownvoltage) * 100
 
 
 def call_script(script, timeout=SHUTDOWN_TIMEOUT):
@@ -227,10 +265,12 @@ def loop(args):
                     if len(window_stats[stat]) > 1:
                         window_diffs[stat] = mean_diff(window_stats[stat])
                 if window_diffs and sample_count >= args.window_samples:
-                    soc = calc_soc(response[MEAN_V], args)
+                    fullvoltage = seasonal_fullvoltage(args)
+                    soc = calc_soc(response[MEAN_V], args, fullvoltage)
                     window_summary = {
                         'window_diffs': window_diffs,
                         'soc': soc,
+                        'fullvoltage': fullvoltage,
                     }
                     log_json(args.log, window_summary, args.prometheus)
 
@@ -278,7 +318,16 @@ def parse_args():
         help='current in mA at which the Pi is considered shutdown')
     parser.add_argument(
         '--fullvoltage', default=13.3, type=float,
-        help='voltage at which the battery is considered full')
+        help='voltage at which the battery is considered full (the '
+             'lightest-day value when --winter-fullvoltage is set)')
+    parser.add_argument(
+        '--winter-fullvoltage', default=0.0, type=float,
+        help='full voltage at the darkest day of the year; if set (>0), the '
+             'considered-full threshold is scaled by photoperiod between this '
+             'and --fullvoltage so the Pi sleeps more in the dark season')
+    parser.add_argument(
+        '--latitude', default=0.0, type=float,
+        help='site latitude in degrees (negative south) for --winter-fullvoltage')
     parser.add_argument(
         '--minsleepmins', default=MIN_SLEEP_MINS, type=float,
         help='minimum time to sleep')
@@ -307,6 +356,8 @@ def parse_args():
     main_args = parser.parse_args()
     assert main_args.shutdownvoltage > main_args.deepsleepvoltage
     assert main_args.fullvoltage > main_args.shutdownvoltage
+    if main_args.winter_fullvoltage:
+        assert main_args.winter_fullvoltage > main_args.fullvoltage
     return main_args
 
 

--- a/sleepypid/test_sleepypid.py
+++ b/sleepypid/test_sleepypid.py
@@ -5,7 +5,10 @@ import os
 import tempfile
 import unittest
 from collections import namedtuple
-from sleepypid import get_uptime, mean_diff, sleep_duty_seconds, calc_soc, log_grafana, call_script, parse_args, override_args
+from prometheus_client import REGISTRY
+from sleepypid import (
+    get_uptime, mean_diff, sleep_duty_seconds, calc_soc, flatten_telemetry,
+    log_prometheus, call_script, parse_args, override_args)
 
 
 class SleepyidTestCase(unittest.TestCase):
@@ -29,18 +32,47 @@ class SleepyidTestCase(unittest.TestCase):
         self.assertEqual(0, calc_soc(12.8, args))
         self.assertAlmostEqual(50, calc_soc(13.1, args), places=2)
 
-    def test_log_grafana(self):
-        with tempfile.TemporaryDirectory() as test_dir:
-            log_grafana(True, test_dir,
-                {"command": {"command": "sensors"},
-                 "response": {"command": "sensors", "error": "", "rpiCurrent": 1, "supplyVoltage": 1, "mean1mSupplyVoltage": 1,
-                              "mean1mRpiCurrent": 1, "min1mSupplyVoltage": 1, "min1mRpiCurrent": 1, "max1mSupplyVoltage": 1,
-                              "max1mRpiCurrent": 1, "meanValid": True, "powerState": True, "powerStateOverride": False, "uptimems": 1},
-                              "timestamp": 1, "utctimestamp": "2021-01-01 01:11:11.11",
-                              "loadavg": [1, 1, 1], "uptime": 1, "cputempc": 5}, True)
-            log_grafana(True, test_dir,
-                {"window_diffs": {"mean1mRpiCurrent": 0.1, "mean1mSupplyVoltage": -0.01, "cputempc": 0.01}, "soc": 100, "timestamp": 1,
-                                  "utctimestamp": "2021-01-01 01:11:11.11", "loadavg": [1, 1, 1], "uptime": 1, "cputempc": 5}, True)
+    def test_flatten_telemetry(self):
+        flat = flatten_telemetry(
+            {"command": {"command": "sensors"},
+             "response": {"command": "sensors", "error": "", "rpiCurrent": 1,
+                          "supplyVoltage": 2, "meanValid": True},
+             "loadavg": [1, 2, 3], "window_diffs": {"cputempc": 0.01}})
+        # response keys hoisted to the top level
+        self.assertEqual(1, flat["rpiCurrent"])
+        self.assertEqual(2, flat["supplyVoltage"])
+        self.assertNotIn("response", flat)
+        # loadavg tuple expanded into per-window keys
+        self.assertEqual(1, flat["loadavg1m"])
+        self.assertEqual(3, flat["loadavg15m"])
+        self.assertNotIn("loadavg", flat)
+        # window_diffs flattened with a suffix
+        self.assertEqual(0.01, flat["cputempc_window_diffs"])
+        self.assertNotIn("window_diffs", flat)
+
+    def test_log_prometheus(self):
+        log_prometheus(False, {"soc": 42})
+        self.assertIsNone(REGISTRY.get_sample_value("sleepypi_soc"))
+        log_prometheus(True,
+            {"command": {"command": "sensors"},
+             "response": {"command": "sensors", "error": "", "rpiCurrent": 1, "supplyVoltage": 1, "mean1mSupplyVoltage": 1,
+                          "mean1mRpiCurrent": 1, "min1mSupplyVoltage": 1, "min1mRpiCurrent": 1, "max1mSupplyVoltage": 1,
+                          "max1mRpiCurrent": 1, "meanValid": True, "powerState": True, "powerStateOverride": False, "uptimems": 1},
+                          "timestamp": 1, "utctimestamp": "2021-01-01 01:11:11.11",
+                          "loadavg": [1, 1, 1], "uptime": 1, "cputempc": 5})
+        log_prometheus(True,
+            {"window_diffs": {"mean1mRpiCurrent": 0.1, "mean1mSupplyVoltage": -0.01, "cputempc": 0.01}, "soc": 100, "timestamp": 1,
+                              "utctimestamp": "2021-01-01 01:11:11.11", "loadavg": [1, 1, 1], "uptime": 1, "cputempc": 5})
+        # numeric sensor values are exported as gauges
+        self.assertEqual(1, REGISTRY.get_sample_value("sleepypi_mean1mSupplyVoltage"))
+        # booleans are coerced to 0/1
+        self.assertEqual(1, REGISTRY.get_sample_value("sleepypi_powerState"))
+        self.assertEqual(0, REGISTRY.get_sample_value("sleepypi_powerStateOverride"))
+        # window diffs and derived values are exported
+        self.assertEqual(100, REGISTRY.get_sample_value("sleepypi_soc"))
+        self.assertAlmostEqual(0.01, REGISTRY.get_sample_value("sleepypi_cputempc_window_diffs"))
+        # non-numeric values (strings/dicts) are not exported
+        self.assertIsNone(REGISTRY.get_sample_value("sleepypi_utctimestamp"))
 
     def test_mean_diff(self):
         self.assertEqual(0, mean_diff([0, 1, 2, 3, 4, 3, 2, 1, 0]))

--- a/sleepypid/test_sleepypid.py
+++ b/sleepypid/test_sleepypid.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import datetime
 import json
 import os
 import tempfile
@@ -9,7 +10,8 @@ from prometheus_client import REGISTRY
 import sleepypid
 from sleepypid import (
     get_uptime, mean_diff, sleep_duty_seconds, calc_soc, flatten_telemetry,
-    log_prometheus, call_script, parse_args, override_args)
+    log_prometheus, call_script, parse_args, override_args,
+    daylength_hours, seasonal_fullvoltage)
 
 
 class SleepyidTestCase(unittest.TestCase):
@@ -32,6 +34,47 @@ class SleepyidTestCase(unittest.TestCase):
         self.assertEqual(0, calc_soc(12.9, args))
         self.assertEqual(0, calc_soc(12.8, args))
         self.assertAlmostEqual(50, calc_soc(13.1, args), places=2)
+
+    def test_calc_soc_dynamic_fullvoltage(self):
+        args = namedtuple('args', ('fullvoltage', 'shutdownvoltage'))
+        args.fullvoltage = 26.0
+        args.shutdownvoltage = 24.3
+        # default uses args.fullvoltage
+        self.assertAlmostEqual(41.18, calc_soc(25.0, args), places=1)
+        # an explicit (e.g. winter) higher full -> lower SOC for the same
+        # voltage -> the Pi is more likely to sleep
+        soc_summer = calc_soc(25.0, args, 26.0)
+        soc_winter = calc_soc(25.0, args, 27.0)
+        self.assertGreater(soc_summer, soc_winter)
+        self.assertAlmostEqual(25.93, soc_winter, places=1)
+
+    def test_daylength_hours(self):
+        # southern hemisphere: winter solstice (Jun) shorter than summer (Dec)
+        june = daylength_hours(172, -41.1)
+        december = daylength_hours(355, -41.1)
+        self.assertLess(june, december)
+        self.assertAlmostEqual(june, 9.2, delta=0.4)
+        self.assertAlmostEqual(december, 15.1, delta=0.4)
+        # equator is ~12h year round
+        self.assertAlmostEqual(daylength_hours(172, 0.0), 12.0, delta=0.2)
+
+    def test_seasonal_fullvoltage(self):
+        args = namedtuple('args', ('fullvoltage', 'winter_fullvoltage', 'latitude'))
+        args.fullvoltage = 26.0
+        args.winter_fullvoltage = 27.0
+        args.latitude = -41.102223
+        winter = seasonal_fullvoltage(args, datetime.date(2026, 6, 21))
+        summer = seasonal_fullvoltage(args, datetime.date(2026, 12, 21))
+        # darkest day -> near the winter bar, lightest day -> near summer
+        self.assertAlmostEqual(winter, 27.0, delta=0.05)
+        self.assertAlmostEqual(summer, 26.0, delta=0.05)
+        self.assertGreater(winter, summer)
+        # disabled (winter_fullvoltage falsy) -> static fullvoltage
+        off = namedtuple('args', ('fullvoltage', 'winter_fullvoltage', 'latitude'))
+        off.fullvoltage = 25.0
+        off.winter_fullvoltage = 0.0
+        off.latitude = -41.1
+        self.assertEqual(25.0, seasonal_fullvoltage(off, datetime.date(2026, 6, 21)))
 
     def test_flatten_telemetry(self):
         flat = flatten_telemetry(

--- a/sleepypid/test_sleepypid.py
+++ b/sleepypid/test_sleepypid.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from collections import namedtuple
 from prometheus_client import REGISTRY
+import sleepypid
 from sleepypid import (
     get_uptime, mean_diff, sleep_duty_seconds, calc_soc, flatten_telemetry,
     log_prometheus, call_script, parse_args, override_args)
@@ -73,6 +74,22 @@ class SleepyidTestCase(unittest.TestCase):
         self.assertAlmostEqual(0.01, REGISTRY.get_sample_value("sleepypi_cputempc_window_diffs"))
         # non-numeric values (strings/dicts) are not exported
         self.assertIsNone(REGISTRY.get_sample_value("sleepypi_utctimestamp"))
+
+    def test_prometheus_prefix_empty(self):
+        # an empty prefix exports bare metric names for drop-in compatibility
+        # with the legacy pushgateway series (e.g. ridge-pi deployment).
+        original_prefix = sleepypid.prometheus_prefix
+        sleepypid.prometheus_prefix = ''
+        try:
+            log_prometheus(True, {"window_diffs": {}, "legacyBareMetric": 7})
+        finally:
+            sleepypid.prometheus_prefix = original_prefix
+        self.assertEqual(7, REGISTRY.get_sample_value("legacyBareMetric"))
+        self.assertIsNone(REGISTRY.get_sample_value("sleepypi_legacyBareMetric"))
+
+    def test_prometheus_prefix_arg(self):
+        args = parse_args()
+        self.assertEqual('sleepypi_', args.prometheus_prefix)
 
     def test_mean_diff(self):
         self.assertEqual(0, mean_diff([0, 1, 2, 3, 4, 3, 2, 1, 0]))


### PR DESCRIPTION
Replaces the Grafana-JSON/SSH-push telemetry path with a native Prometheus endpoint, plus two follow-ups now deployed on ridge-pi.

## Changes
- **Prometheus endpoint**: `start_http_server` exposes telemetry as gauges on `:9110` (`--prometheus-port`, `--no-prometheus`); drops the `--grafana` JSON path. `flatten_telemetry()` flattens loadavg / `response.*` / `window_diffs` as the old Grafana path did. Dockerised build + test stage; `python-test` CI.
- **Configurable `--prometheus-prefix`**: default `sleepypi_`; empty (`--prometheus-prefix=`) gives **bare** names (`mean1mSupplyVoltage`, `soc`, …), drop-in compatible with the legacy pushgateway series so existing dashboards/alerts survive the move from SSH+cron push to a direct scrape.
- **Seasonal full-voltage** (opt-in): `--winter-fullvoltage` + `--latitude`. When set, `--fullvoltage` is the summer (lightest-day) value and the considered-full threshold is photoperiod-interpolated (Forsythe et al. 1995 daylength) up to the winter value, so SOC reads lower and the Pi duty-cycles more as daylight shrinks. Unset = static. `fullvoltage` is software-only (`calc_soc`), never pushed to firmware; the effective value is exported as telemetry.

## Tests
`docker build --target test` (the CI stage) green locally: **13 tests pass**, `pylint --fail-under=8` (9.40/10). New coverage for `flatten_telemetry`, prefix handling, `daylength_hours`, `seasonal_fullvoltage`, dynamic-`fullvoltage` SOC.

## Deployed
Vendored into the finf-ansible `sleepypid` role and live on ridge-pi: bare-name scrape on `:9110`, seasonal envelope `fullvoltage=26.0` / `winter_fullvoltage=27.0` at lat −41.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)