### PR TITLE
Bump actions/checkout from master to v6

### DIFF
--- a/.github/workflows/arduino-test.yml
+++ b/.github/workflows/arduino-test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
       - name: Install
         run: |
           sudo apt-get update && sudo apt-get -qyf install wget unzip python3-dev


### PR DESCRIPTION
Floating `@master` tag is unpinned and can break unannounced. `@v6` is the current major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)