### PR TITLE
Forecast-aware full-voltage scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ day counts as zero (err sleepy).
 
 Providers (`--forecast-provider`):
 
-- `metservice` (default) — the NZ MetService / MetOcean Point Forecast API.
-  Requires a free API key from <https://console.metoceanapi.com/> passed via
-  `--forecast-key`.
-- `open-meteo` — keyless, works out of the box; good for testing.
+- `open-meteo` (default) — keyless and free, works out of the box. Not an
+  NZ-government source, but it serves NZ-region model data.
+- `metservice` — the NZ MetService / MetOcean Point Forecast API. A **paid**
+  plan (from ~US$30/mo, <https://console.metoceanapi.com/>) with the key passed
+  via `--forecast-key`. The response parser is coded against the documented
+  schema but is **unverified against a live response** — confirm it before
+  relying on it.
 - `none` — disable fetching.
 
 Set `--latitude` and `--longitude` for the site. The forecast is fetched at most
@@ -56,14 +59,16 @@ up to `--forecast-max-age-hours` (default 48), after which the bump reverts to
 zero (seasonal-only) — never permanently sleepy, or the node could never wake
 long enough to fetch a fresh forecast.
 
-Example:
+Example (keyless default provider):
 
 ```
 sleepypid.py --winter-fullvoltage 27.0 --fullvoltage 26.0 \
   --latitude -41.1 --longitude 174.8 \
-  --forecast-provider metservice --forecast-key $METSERVICE_KEY \
   --forecast-fullvoltage-span 0.4
 ```
+
+To use the paid MetService source instead, add
+`--forecast-provider metservice --forecast-key $METSERVICE_KEY`.
 
 ## Prometheus metrics
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,55 @@
 `sleepypid/sleepypid.py` polls the SleepyPi hat over serial, manages sleep/wake
 duty cycling, and logs telemetry.
 
+## Seasonal full-voltage scaling
+
+For a solar-charged node the battery's "considered full" threshold can be tuned
+to the time of year and site latitude. Set `--winter-fullvoltage` (the darkest-day
+threshold) and `--latitude`; the threshold is then interpolated by today's
+photoperiod between `--winter-fullvoltage` and `--fullvoltage` (the lightest-day
+value). Shorter days raise the threshold, so the battery reads as less full, the
+state-of-charge drops, and the Pi sleeps more. It is off (static `--fullvoltage`)
+unless `--winter-fullvoltage` is set.
+
+## Solar forecast scaling
+
+On top of the seasonal threshold, the daemon can fetch a short-range solar
+forecast and sleep *more* when restricted sunlight is coming, so a cloudy spell
+in an already-short-day season doesn't flatten the battery. The bias is
+deliberately conservative: over-sleeping is fine, draining the battery is not.
+
+Enable it by setting `--forecast-fullvoltage-span` (>0), the maximum extra volts
+added to the threshold when no sunlight is forecast. The applied bump is
+`(1 - light_factor) * span`, where `light_factor` is the next
+`--forecast-days` (default 3) of forecast shortwave radiation divided by a
+clear-sky reference (derived from latitude/day-of-year) and averaged. A missing
+day counts as zero (err sleepy).
+
+Providers (`--forecast-provider`):
+
+- `metservice` (default) — the NZ MetService / MetOcean Point Forecast API.
+  Requires a free API key from <https://console.metoceanapi.com/> passed via
+  `--forecast-key`.
+- `open-meteo` — keyless, works out of the box; good for testing.
+- `none` — disable fetching.
+
+Set `--latitude` and `--longitude` for the site. The forecast is fetched at most
+once per `--forecast-refresh-hours` (default 6) and cached to
+`--forecast-cache` (default `/var/lib/sleepypid/forecast.json`) so a single fetch
+covers a whole wake/sleep cycle. On a failed fetch the last forecast is held for
+up to `--forecast-max-age-hours` (default 48), after which the bump reverts to
+zero (seasonal-only) — never permanently sleepy, or the node could never wake
+long enough to fetch a fresh forecast.
+
+Example:
+
+```
+sleepypid.py --winter-fullvoltage 27.0 --fullvoltage 26.0 \
+  --latitude -41.1 --longitude 174.8 \
+  --forecast-provider metservice --forecast-key $METSERVICE_KEY \
+  --forecast-fullvoltage-span 0.4
+```
+
 ## Prometheus metrics
 
 By default the daemon exposes its current sensor values and derived state as
@@ -24,6 +73,17 @@ with `--no-prometheus`). Point a Prometheus scrape at `http://<host>:9110/metric
 instead of parsing the log file. All metrics are prefixed `sleepypi_`, e.g.
 `sleepypi_mean1mSupplyVoltage`, `sleepypi_mean1mRpiCurrent`, `sleepypi_soc`,
 `sleepypi_powerState`, and `sleepypi_cputempc`.
+
+When solar forecast scaling is enabled, these are also exported:
+
+- `sleepypi_forecast_factor` — expected clear-sky fraction `[0,1]` (1 = clear).
+- `sleepypi_forecast_bump` — volts added to the considered-full threshold.
+- `sleepypi_forecast_age_seconds` — age of the forecast in use (`-1` if none).
+- `sleepypi_forecast_fetch_ok` / `sleepypi_forecast_fetch_error` — `1/0` for the
+  last attempt's outcome.
+- `sleepypi_forecast_source_<provider>` — `1` for the active provider, else `0`.
+- `sleepypi_forecast_errors_<provider>` — cumulative fetch failures per provider,
+  persisted across restarts so a failing source can be alerted on.
 
 ## Running the tests
 

--- a/sleepypid/sleepypid.py
+++ b/sleepypid/sleepypid.py
@@ -292,6 +292,10 @@ def parse_metservice(payload):
 
     Integrates the hourly radiation.shortwave flux (W/m^2) over each UTC day:
     W/m^2 sustained for one hour is W/m^2 * 3600 s = J/m^2, /1e6 -> MJ/m^2.
+
+    NOTE: coded against the documented CF-JSON shape but UNVERIFIED against a
+    live response (MetService is a paid plan). Confirm the field layout before
+    relying on it; only this parser and forecast_request should need changing.
     """
     dims = payload.get('dimensions', {})
     times = dims.get('time', {}).get('data', [])
@@ -578,13 +582,14 @@ def parse_args():
              'scaling on top of the seasonal threshold (the Pi sleeps more when '
              'restricted sunlight is forecast)')
     parser.add_argument(
-        '--forecast-provider', default='metservice',
+        '--forecast-provider', default='open-meteo',
         choices=sorted(FORECAST_PARSERS) + ['none'],
-        help='solar forecast source (metservice needs --forecast-key)')
+        help='solar forecast source; open-meteo is keyless, metservice is the '
+             'paid NZ MetService API and needs --forecast-key')
     parser.add_argument(
         '--forecast-key', default='',
-        help='API key for the forecast provider (free for metservice from '
-             'console.metoceanapi.com)')
+        help='API key for the forecast provider (required for metservice, a '
+             'paid plan from console.metoceanapi.com)')
     parser.add_argument(
         '--forecast-days', default=3, type=int,
         help='number of forecast days to average available sunlight over')

--- a/sleepypid/sleepypid.py
+++ b/sleepypid/sleepypid.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 import time
 import os
+import urllib.parse
+import urllib.request
 from collections import defaultdict
 import serial
 from prometheus_client import Gauge, start_http_server
@@ -232,6 +234,234 @@ def calc_soc(mean_v, args, fullvoltage=None):
     return (mean_v - args.shutdownvoltage) / (fullvoltage - args.shutdownvoltage) * 100
 
 
+def extraterrestrial_radiation(day_of_year, latitude):
+    """Daily top-of-atmosphere radiation Ra in MJ/m^2 (FAO-56 eq. 21).
+
+    The astronomical upper bound on a day's solar energy at this latitude;
+    used as the clear-sky reference the forecast is normalised against.
+    """
+    lat = math.radians(latitude)
+    dr = 1 + 0.033 * math.cos(2 * math.pi * day_of_year / 365)
+    decl = 0.409 * math.sin(2 * math.pi * day_of_year / 365 - 1.39)
+    arg = max(-1.0, min(1.0, -math.tan(lat) * math.tan(decl)))
+    sunset = math.acos(arg)
+    gsc = 0.0820  # solar constant, MJ/m^2/min
+    ra = (24 * 60 / math.pi) * gsc * dr * (
+        sunset * math.sin(lat) * math.sin(decl) +
+        math.cos(lat) * math.cos(decl) * math.sin(sunset))
+    return max(0.0, ra)
+
+
+def clearsky_radiation(day_of_year, latitude):
+    """Clear-sky surface solar radiation Rso in MJ/m^2 (FAO-56, ~0.75*Ra)."""
+    return 0.75 * extraterrestrial_radiation(day_of_year, latitude)
+
+
+def forecast_light_factor(daily_ghi, when, latitude):
+    """Expected fraction of clear-sky sunlight over the forecast days [0,1].
+
+    daily_ghi is the per-day forecast global horizontal irradiation (MJ/m^2),
+    the first entry for `when`. Each day is divided by its clear-sky reference
+    and capped at 1.0; a missing day (None) counts as 0.0 so we err sleepy.
+    Returns 1.0 (neutral, no bump) when there is nothing usable to act on.
+    """
+    ratios = []
+    for offset, ghi in enumerate(daily_ghi):
+        day = when + datetime.timedelta(days=offset)
+        clearsky = clearsky_radiation(day.timetuple().tm_yday, latitude)
+        if clearsky <= 0:
+            continue
+        if ghi is None:
+            ratios.append(0.0)
+            continue
+        ratios.append(max(0.0, min(1.0, ghi / clearsky)))
+    if not ratios:
+        return 1.0
+    return statistics.mean(ratios)
+
+
+def parse_open_meteo(payload):
+    """Open-Meteo daily payload -> per-day GHI in MJ/m^2 (shortwave_radiation_sum)."""
+    daily = payload.get('daily', {})
+    values = daily.get('shortwave_radiation_sum', [])
+    return [None if v is None else float(v) for v in values]
+
+
+def parse_metservice(payload):
+    """MetService/MetOcean point/time payload -> per-day GHI in MJ/m^2.
+
+    Integrates the hourly radiation.shortwave flux (W/m^2) over each UTC day:
+    W/m^2 sustained for one hour is W/m^2 * 3600 s = J/m^2, /1e6 -> MJ/m^2.
+    """
+    dims = payload.get('dimensions', {})
+    times = dims.get('time', {}).get('data', [])
+    var = payload.get('variables', {}).get('radiation.shortwave', {})
+    values = var.get('data', [])
+    nodata = payload.get('noData')
+    daily = defaultdict(float)
+    for ts, val in zip(times, values):
+        if val is None or (nodata is not None and val == nodata):
+            continue
+        day = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc).date()
+        daily[day] += float(val) * 3600 / 1e6
+    return [daily[day] for day in sorted(daily)]
+
+
+FORECAST_PARSERS = {
+    'open-meteo': parse_open_meteo,
+    'metservice': parse_metservice,
+}
+
+
+def forecast_request(args):
+    """Build (url, headers, body) for the configured forecast provider."""
+    if args.forecast_provider == 'open-meteo':
+        base = args.forecast_url or 'https://api.open-meteo.com/v1/forecast'
+        query = urllib.parse.urlencode({
+            'latitude': args.latitude,
+            'longitude': args.longitude,
+            'daily': 'shortwave_radiation_sum',
+            'forecast_days': args.forecast_days,
+            'timezone': 'UTC',
+        })
+        return ('%s?%s' % (base, query), {}, None)
+    if args.forecast_provider == 'metservice':
+        base = args.forecast_url or 'https://forecast-v2.metoceanapi.com/point/time'
+        body = json.dumps({
+            'points': [{'lon': args.longitude, 'lat': args.latitude}],
+            'variables': ['radiation.shortwave'],
+            'time': {
+                'from': datetime.datetime.now(
+                    datetime.timezone.utc).strftime('%Y-%m-%dT%H:00:00Z'),
+                'interval': '1h',
+                'repeat': args.forecast_days * 24,
+            },
+        }).encode()
+        headers = {'x-api-key': args.forecast_key, 'Content-Type': 'application/json'}
+        return (base, headers, body)
+    raise ValueError('unknown forecast provider %s' % args.forecast_provider)
+
+
+def fetch_forecast(args):
+    """Fetch and JSON-decode the raw forecast payload (network IO)."""
+    url, headers, body = forecast_request(args)
+    request = urllib.request.Request(
+        url, data=body, headers=headers, method='POST' if body else 'GET')
+    with urllib.request.urlopen(request, timeout=args.forecast_timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def load_forecast_cache(path):
+    """Return the cached forecast dict, or None if absent/unreadable."""
+    try:
+        with open(path, encoding='utf-8') as cache:
+            return json.loads(cache.read())
+    except (OSError, ValueError):
+        return None
+
+
+def save_forecast_cache(path, obj):
+    """Persist the forecast dict so the factor survives sleep cycles."""
+    parent = os.path.dirname(path)
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent, exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as cache:
+        cache.write(json.dumps(obj))
+
+
+def forecast_status(args, factor, age, cache, outcome):
+    """Numeric forecast telemetry for Prometheus.
+
+    outcome is 'live' (fresh fetch), 'cache' (reused, no attempt) or 'error'
+    (fetch failed). Exposes the applied factor, cache age, the last outcome,
+    which provider is active, and a persisted cumulative error count per
+    provider so Prometheus can alert on a failing source even though the daemon
+    restarts every wake.
+    """
+    status = {
+        'forecast_factor': factor,
+        'forecast_age_seconds': -1.0 if age is None else age,
+        'forecast_fetch_ok': int(outcome == 'live'),
+        'forecast_fetch_error': int(outcome == 'error'),
+    }
+    errors = (cache or {}).get('errors', {})
+    for provider in FORECAST_PARSERS:
+        key = provider.replace('-', '_')
+        status['forecast_source_' + key] = int(provider == args.forecast_provider)
+        status['forecast_errors_' + key] = errors.get(provider, 0)
+    return status
+
+
+def record_forecast_error(args, cache):
+    """Increment and persist the per-provider error count, keeping any cached factor."""
+    if cache is None:
+        cache = {'ts': 0, 'errors': {}}
+    errors = cache.setdefault('errors', {})
+    errors[args.forecast_provider] = errors.get(args.forecast_provider, 0) + 1
+    try:
+        save_forecast_cache(args.forecast_cache, cache)
+    except OSError:
+        pass
+    return cache
+
+
+def update_forecast(args, now=None, fetcher=fetch_forecast):
+    """Return (light_factor, status), honouring cache + fail-sleepy semantics.
+
+    Fetches at most once per --forecast-refresh-hours and persists to
+    --forecast-cache, so a single fetch covers a whole wake/sleep cycle. On a
+    failed fetch the last cached factor is held until --forecast-max-age-hours,
+    after which it reverts to 1.0 (seasonal-only) -- never permanently sleepy,
+    or the node could never wake long enough to fetch a fresh forecast. status
+    is numeric telemetry (see forecast_status) merged into the Prometheus feed.
+    """
+    if now is None:
+        now = time.time()
+    cache = load_forecast_cache(args.forecast_cache)
+    if cache and 'factor' in cache:
+        age = now - cache.get('ts', 0)
+        if age < args.forecast_refresh_hours * 3600:
+            return cache['factor'], forecast_status(args, cache['factor'], age, cache, 'cache')
+    try:
+        daily = FORECAST_PARSERS[args.forecast_provider](fetcher(args))
+        when = datetime.datetime.fromtimestamp(now, datetime.timezone.utc).date()
+        factor = forecast_light_factor(daily, when, args.latitude)
+        new_cache = {
+            'ts': now, 'provider': args.forecast_provider,
+            'lat': args.latitude, 'lon': args.longitude,
+            'factor': factor, 'daily_ghi': daily,
+            'errors': (cache or {}).get('errors', {}),
+        }
+        save_forecast_cache(args.forecast_cache, new_cache)
+        return factor, forecast_status(args, factor, 0.0, new_cache, 'live')
+    except (OSError, ValueError, KeyError):
+        cache = record_forecast_error(args, cache)
+        if 'factor' in cache:
+            age = now - cache.get('ts', 0)
+            if age < args.forecast_max_age_hours * 3600:
+                return cache['factor'], forecast_status(args, cache['factor'], age, cache, 'error')
+        return 1.0, forecast_status(args, 1.0, None, cache, 'error')
+
+
+def forecast_enabled(args):
+    """True when forecast scaling is opted in (a span and a real provider)."""
+    return (getattr(args, 'forecast_fullvoltage_span', 0.0) > 0 and
+            getattr(args, 'forecast_provider', 'none') != 'none')
+
+
+def effective_fullvoltage(args, factor, when=None):
+    """Seasonal full voltage plus a forecast bump when sunlight is restricted.
+
+    factor is the expected clear-sky fraction [0,1]; less light -> larger bump
+    -> battery reads less full -> the Pi sleeps more.
+    """
+    full = seasonal_fullvoltage(args, when)
+    span = getattr(args, 'forecast_fullvoltage_span', 0.0)
+    if not span or factor is None:
+        return full
+    return full + (1.0 - max(0.0, min(1.0, factor))) * span
+
+
 def call_script(script, timeout=SHUTDOWN_TIMEOUT):
     """Call an external script with a timeout."""
     return subprocess.call(['timeout', str(timeout), script])
@@ -244,9 +474,15 @@ def loop(args):
     window_stats = defaultdict(list)
     window_diffs = {}
     ticker = 0
+    forecast_factor = 1.0
+    forecast_telemetry = {}
+    next_forecast = 0
 
     # TODO: sync sleepypi rtc with settime/hwclock -w if out of sync
     while True:
+        if forecast_enabled(args) and time.time() >= next_forecast:
+            forecast_factor, forecast_telemetry = update_forecast(args)
+            next_forecast = time.time() + args.forecast_refresh_hours * 3600
         summary = None
         try:
             summary, command_error = send_command({'command': 'sensors'}, args)
@@ -265,13 +501,17 @@ def loop(args):
                     if len(window_stats[stat]) > 1:
                         window_diffs[stat] = mean_diff(window_stats[stat])
                 if window_diffs and sample_count >= args.window_samples:
-                    fullvoltage = seasonal_fullvoltage(args)
+                    fullvoltage = effective_fullvoltage(args, forecast_factor)
                     soc = calc_soc(response[MEAN_V], args, fullvoltage)
                     window_summary = {
                         'window_diffs': window_diffs,
                         'soc': soc,
                         'fullvoltage': fullvoltage,
                     }
+                    if forecast_enabled(args):
+                        window_summary.update(forecast_telemetry)
+                        window_summary['forecast_bump'] = (
+                            fullvoltage - seasonal_fullvoltage(args))
                     log_json(args.log, window_summary, args.prometheus)
 
                     if args.sleepscript and (sample_count % args.window_samples == 0):
@@ -329,6 +569,42 @@ def parse_args():
         '--latitude', default=0.0, type=float,
         help='site latitude in degrees (negative south) for --winter-fullvoltage')
     parser.add_argument(
+        '--longitude', default=0.0, type=float,
+        help='site longitude in degrees (negative west) for the solar forecast')
+    parser.add_argument(
+        '--forecast-fullvoltage-span', default=0.0, type=float,
+        help='max extra volts added to the considered-full threshold when the '
+             'solar forecast shows no sunlight; if set (>0), enables forecast '
+             'scaling on top of the seasonal threshold (the Pi sleeps more when '
+             'restricted sunlight is forecast)')
+    parser.add_argument(
+        '--forecast-provider', default='metservice',
+        choices=sorted(FORECAST_PARSERS) + ['none'],
+        help='solar forecast source (metservice needs --forecast-key)')
+    parser.add_argument(
+        '--forecast-key', default='',
+        help='API key for the forecast provider (free for metservice from '
+             'console.metoceanapi.com)')
+    parser.add_argument(
+        '--forecast-days', default=3, type=int,
+        help='number of forecast days to average available sunlight over')
+    parser.add_argument(
+        '--forecast-cache', default='/var/lib/sleepypid/forecast.json',
+        help='file to persist the last forecast across sleep cycles')
+    parser.add_argument(
+        '--forecast-refresh-hours', default=6.0, type=float,
+        help='re-fetch the forecast no more often than this')
+    parser.add_argument(
+        '--forecast-max-age-hours', default=48.0, type=float,
+        help='hold the last forecast this long on fetch failure before '
+             'reverting to the seasonal-only threshold')
+    parser.add_argument(
+        '--forecast-timeout', default=15, type=int,
+        help='solar forecast HTTP timeout in seconds')
+    parser.add_argument(
+        '--forecast-url', default='',
+        help='override the forecast provider base URL (mainly for testing)')
+    parser.add_argument(
         '--minsleepmins', default=MIN_SLEEP_MINS, type=float,
         help='minimum time to sleep')
     parser.add_argument(
@@ -358,6 +634,8 @@ def parse_args():
     assert main_args.fullvoltage > main_args.shutdownvoltage
     if main_args.winter_fullvoltage:
         assert main_args.winter_fullvoltage > main_args.fullvoltage
+    if forecast_enabled(main_args) and main_args.forecast_provider == 'metservice':
+        assert main_args.forecast_key, '--forecast-provider metservice requires --forecast-key'
     return main_args
 
 

--- a/sleepypid/test_sleepypid.py
+++ b/sleepypid/test_sleepypid.py
@@ -6,12 +6,15 @@ import os
 import tempfile
 import unittest
 from collections import namedtuple
+from types import SimpleNamespace
 from prometheus_client import REGISTRY
 import sleepypid
 from sleepypid import (
     get_uptime, mean_diff, sleep_duty_seconds, calc_soc, flatten_telemetry,
     log_prometheus, call_script, parse_args, override_args,
-    daylength_hours, seasonal_fullvoltage)
+    daylength_hours, seasonal_fullvoltage,
+    extraterrestrial_radiation, clearsky_radiation, forecast_light_factor,
+    parse_open_meteo, parse_metservice, effective_fullvoltage, update_forecast)
 
 
 class SleepyidTestCase(unittest.TestCase):
@@ -75,6 +78,125 @@ class SleepyidTestCase(unittest.TestCase):
         off.winter_fullvoltage = 0.0
         off.latitude = -41.1
         self.assertEqual(25.0, seasonal_fullvoltage(off, datetime.date(2026, 6, 21)))
+
+    def test_extraterrestrial_radiation(self):
+        # FAO-56 Example 8: 3 September (day 246) at 20 S -> Ra ~ 32.2 MJ/m^2
+        self.assertAlmostEqual(32.2, extraterrestrial_radiation(246, -20.0), delta=0.3)
+        # clear-sky surface reference is 0.75 * Ra
+        self.assertAlmostEqual(
+            0.75 * extraterrestrial_radiation(246, -20.0),
+            clearsky_radiation(246, -20.0), places=5)
+
+    def test_forecast_light_factor(self):
+        when = datetime.date(2026, 6, 21)
+        lat = -41.102223
+        clearsky = clearsky_radiation(when.timetuple().tm_yday, lat)
+        # a clear forecast (~ clear-sky energy) -> full light, no extra sleep
+        self.assertGreater(forecast_light_factor([clearsky] * 3, when, lat), 0.95)
+        # heavily clouded forecast -> little light -> sleepier
+        self.assertAlmostEqual(
+            0.2, forecast_light_factor([clearsky * 0.2] * 3, when, lat), delta=0.05)
+        # a missing day counts as zero (err sleepy); empty -> neutral 1.0
+        self.assertAlmostEqual(
+            0.5, forecast_light_factor([None, clearsky], when, lat), delta=0.05)
+        self.assertEqual(1.0, forecast_light_factor([], when, lat))
+
+    def test_effective_fullvoltage(self):
+        args = SimpleNamespace(
+            fullvoltage=26.0, winter_fullvoltage=0.0, latitude=-41.1,
+            forecast_fullvoltage_span=0.5)
+        when = datetime.date(2026, 6, 21)
+        # factor 1.0 (clear) -> seasonal value unchanged
+        self.assertAlmostEqual(26.0, effective_fullvoltage(args, 1.0, when), places=5)
+        # factor 0.0 (dark) -> seasonal + full span -> sleepier
+        self.assertAlmostEqual(26.5, effective_fullvoltage(args, 0.0, when), places=5)
+        self.assertAlmostEqual(26.25, effective_fullvoltage(args, 0.5, when), places=5)
+        # span 0 disables the forecast bump entirely
+        args.forecast_fullvoltage_span = 0.0
+        self.assertAlmostEqual(26.0, effective_fullvoltage(args, 0.0, when), places=5)
+
+    def test_parse_open_meteo(self):
+        payload = {"daily": {"time": ["2026-06-02", "2026-06-03", "2026-06-04"],
+                             "shortwave_radiation_sum": [6.0, 4.5, None]}}
+        self.assertEqual([6.0, 4.5, None], parse_open_meteo(payload))
+
+    def test_parse_metservice(self):
+        # hourly W/m^2 integrated to MJ/m^2 per UTC day; noData filtered out
+        payload = {
+            "noData": -9999.0,
+            "dimensions": {"time": {"data": [0, 3600, 7200]}},
+            "variables": {"radiation.shortwave": {"data": [100.0, 200.0, -9999.0]}},
+        }
+        # (100 + 200) W/m^2 * 3600 s / 1e6 = 1.08 MJ/m^2 for 1970-01-01
+        self.assertEqual(1, len(parse_metservice(payload)))
+        self.assertAlmostEqual(1.08, parse_metservice(payload)[0], places=5)
+
+    def _forecast_args(self, cache_path):
+        return SimpleNamespace(
+            forecast_cache=cache_path, forecast_refresh_hours=6.0,
+            forecast_max_age_hours=48.0, forecast_provider='open-meteo',
+            latitude=-41.102223, longitude=174.8, forecast_days=3)
+
+    def test_update_forecast_live(self):
+        now = 1700000000
+        payload = {"daily": {"time": ["a", "b", "c"],
+                             "shortwave_radiation_sum": [1.0, 1.0, 1.0]}}
+        with tempfile.TemporaryDirectory() as test_dir:
+            args = self._forecast_args(os.path.join(test_dir, 'forecast.json'))
+            factor, status = update_forecast(
+                args, now=now, fetcher=lambda a: payload)
+            when = datetime.datetime.fromtimestamp(
+                now, datetime.timezone.utc).date()
+            self.assertAlmostEqual(
+                forecast_light_factor([1.0, 1.0, 1.0], when, args.latitude), factor)
+            self.assertEqual(1, status['forecast_fetch_ok'])
+            self.assertEqual(0, status['forecast_fetch_error'])
+            self.assertEqual(1, status['forecast_source_open_meteo'])
+            self.assertEqual(0, status['forecast_errors_open_meteo'])
+            self.assertTrue(os.path.exists(args.forecast_cache))
+
+    def _write_cache(self, path, **kwargs):
+        with open(path, 'w', encoding='utf-8') as cache:
+            cache.write(json.dumps(kwargs))
+
+    def _boom(self, _args):
+        raise OSError('forecast unreachable')
+
+    def test_update_forecast_fresh_cache(self):
+        now = 1700000000
+        with tempfile.TemporaryDirectory() as test_dir:
+            args = self._forecast_args(os.path.join(test_dir, 'forecast.json'))
+            self._write_cache(args.forecast_cache, ts=now, factor=0.3, errors={})
+            # fresh cache -> reused without calling the (raising) fetcher
+            factor, status = update_forecast(args, now=now, fetcher=self._boom)
+            self.assertEqual(0.3, factor)
+            self.assertEqual(0, status['forecast_fetch_error'])
+
+    def test_update_forecast_stale_cache_held(self):
+        now = 1700000000
+        with tempfile.TemporaryDirectory() as test_dir:
+            args = self._forecast_args(os.path.join(test_dir, 'forecast.json'))
+            # older than refresh (6h) but within max-age (48h) -> hold last value
+            self._write_cache(
+                args.forecast_cache, ts=now - 10 * 3600, factor=0.4, errors={})
+            factor, status = update_forecast(args, now=now, fetcher=self._boom)
+            self.assertEqual(0.4, factor)
+            self.assertEqual(1, status['forecast_fetch_error'])
+            # the failure is counted and persisted for Prometheus
+            self.assertEqual(1, status['forecast_errors_open_meteo'])
+            with open(args.forecast_cache, encoding='utf-8') as cache:
+                self.assertEqual(1, json.loads(cache.read())['errors']['open-meteo'])
+
+    def test_update_forecast_expired_cache_neutral(self):
+        now = 1700000000
+        with tempfile.TemporaryDirectory() as test_dir:
+            args = self._forecast_args(os.path.join(test_dir, 'forecast.json'))
+            # older than max-age -> revert to seasonal-neutral (factor 1.0)
+            self._write_cache(
+                args.forecast_cache, ts=now - 100 * 3600, factor=0.4, errors={})
+            factor, status = update_forecast(args, now=now, fetcher=self._boom)
+            self.assertEqual(1.0, factor)
+            self.assertEqual(1, status['forecast_fetch_error'])
 
     def test_flatten_telemetry(self):
         flat = flatten_telemetry(


### PR DESCRIPTION
## Summary

Adds an opt-in **solar-forecast layer** on top of the existing seasonal/location full-voltage scaling. The seasonal feature knows the *day* will be short; this adds knowledge that the *next 2–3 days are cloudy* and raises the "considered full" threshold further, so the Pi sleeps more before a sunlight-restricted stretch. Bias is deliberately conservative — over-sleeping is fine, draining the battery is not.

**How it works:** fetch short-range shortwave-radiation forecast → average over `--forecast-days` (3) → divide by a clear-sky reference (FAO-56 extraterrestrial radiation × 0.75, from latitude/day-of-year) → `light_factor ∈ [0,1]` → bump = `(1 − light_factor) × --forecast-fullvoltage-span`, added on top of the seasonal threshold. Off unless `--forecast-fullvoltage-span > 0`.

## Design

- **Pluggable providers** (`--forecast-provider`): `open-meteo` (default, free, keyless, validated live) and `metservice` (NZ MetService/MetOcean — a *paid* plan, parser coded to the documented schema but **unverified** against a live response), or `none`.
- **Disk-cached** (`--forecast-cache`): `loop()` exits on sleep and systemd restarts the daemon each wake, so one fetch covers a whole wake/sleep cycle and survives outages.
- **Fail-sleepy + recover:** on fetch failure, hold the last forecast until `--forecast-max-age-hours` (48), then revert to seasonal-neutral — never permanently sleepy, or the node could never wake long enough to fetch again.
- **No new pip dependency** (stdlib `urllib`).

## Prometheus

`forecast_factor`, `forecast_bump`, `forecast_age_seconds`, `forecast_fetch_ok`/`forecast_fetch_error`, `forecast_source_<provider>`, and persisted `forecast_errors_<provider>` (per-source failures surviving restarts, for alerting).

## Tests / verification

- `docker build --target test .` passes: pylint **9.52/10** (gate ≥8), **22 tests** (9 new).
- Live end-to-end run against keyless Open-Meteo confirmed a cloudy NZ-winter forecast raises effective full-voltage as intended.

## Notes

- This branch also carries earlier commits not yet in `main` (seasonal photoperiod scaling, configurable `--prometheus-prefix`).
- `parse_metservice` is unverified (MetService is paid, no key) — clearly flagged in code and README; everything downstream is provider-agnostic, so only that parser would change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)