### PR TITLE
sleepypid: more aggressive seasonal/forecast sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,22 @@ duty cycling, and logs telemetry.
 For a solar-charged node the battery's "considered full" threshold can be tuned
 to the time of year and site latitude. Set `--winter-fullvoltage` (the darkest-day
 threshold) and `--latitude`; the threshold is then interpolated by today's
-photoperiod between `--winter-fullvoltage` and `--fullvoltage` (the lightest-day
-value). Shorter days raise the threshold, so the battery reads as less full, the
-state-of-charge drops, and the Pi sleeps more. It is off (static `--fullvoltage`)
-unless `--winter-fullvoltage` is set.
+clear-sky solar *energy* between `--winter-fullvoltage` and `--fullvoltage` (the
+lightest-day value). Energy (not just daylength) is the driver because winter's
+low sun angle cuts daily charge more than the shorter day alone implies, so the
+winter ramp arrives earlier and deeper. Less energy raises the threshold, so the
+battery reads as less full, the state-of-charge drops, and the Pi sleeps more. It
+is off (static `--fullvoltage`) unless `--winter-fullvoltage` is set.
+
+## Sleep curve
+
+The Pi's sleep duty cycle is the state-of-charge directly, which only yields long
+sleeps once charge is already deep. `--soc-sleep-gamma` (default `1.0`, linear)
+bends that curve: a value `>1` lowers the duty across the mid-range so the node
+sleeps harder for the same charge (e.g. `2.0` roughly triples the sleep at 50%
+SOC) while still keeping 0% and 100% fixed. This amplifies the seasonal and
+forecast adjustments — and the raw SOC — without distorting the logged SOC. The
+applied duty is exported as `sleepypi_duty`.
 
 ## Solar forecast scaling
 

--- a/sleepypid/sleepypid.py
+++ b/sleepypid/sleepypid.py
@@ -62,6 +62,20 @@ def sleep_duty_seconds(duty_cycle, sleep_interval_mins, max_sleep_mins):
     return i * sleep_interval_mins
 
 
+def soc_sleep_duty(soc, gamma):
+    """Bend the SOC->sleep duty curve so low charge sleeps harder.
+
+    sleep_duty_seconds treats the duty cycle as the SOC directly, which only
+    yields long sleeps once SOC is already deep (E[sleep] = interval*(100-d)/d).
+    Raising the normalised SOC to gamma>1 lowers the duty across the mid-range
+    (e.g. gamma=2 takes 50% SOC down to a 25% duty -> ~3x the sleep) while
+    pinning the 0 and 100 endpoints. gamma=1.0 is the original linear behaviour.
+    """
+    if gamma == 1.0:
+        return soc
+    return (max(0.0, soc) / 100.0) ** gamma * 100.0
+
+
 def send_command(command, args):
     """Send a JSON command to the SleepyPi hat and parse response."""
 
@@ -201,12 +215,16 @@ def daylength_hours(day_of_year, latitude):
 
 
 def seasonal_fullvoltage(args, when=None):
-    """Full-charge voltage scaled by photoperiod.
+    """Full-charge voltage scaled by available solar energy.
 
     With args.winter_fullvoltage set, args.fullvoltage is the lightest-day
     (summer) value and winter_fullvoltage the darkest-day value. The threshold
-    is interpolated by today's daylength between the local solstices: less light
-    -> higher threshold -> the battery reads as less full -> the Pi sleeps more.
+    is interpolated by today's clear-sky solar energy between the yearly
+    extremes: less energy -> higher threshold -> the battery reads as less full
+    -> the Pi sleeps more. Energy (not daylength) is the driver because winter's
+    low sun angle cuts daily charge far more than the shorter day alone implies
+    (at mid-latitudes clear-sky energy bottoms out near 0.27x its summer peak,
+    versus ~0.6x for daylength), so the winter ramp arrives earlier and deeper.
     Returns the static args.fullvoltage when winter_fullvoltage is unset.
     """
     winter = getattr(args, 'winter_fullvoltage', 0)
@@ -214,10 +232,10 @@ def seasonal_fullvoltage(args, when=None):
         return args.fullvoltage
     latitude = getattr(args, 'latitude', 0)
     when = when or datetime.date.today()
-    daylengths = [daylength_hours(d, latitude) for d in range(1, 366)]
-    dmin, dmax = min(daylengths), max(daylengths)
-    today = daylength_hours(when.timetuple().tm_yday, latitude)
-    light = (today - dmin) / (dmax - dmin) if dmax > dmin else 1.0
+    energies = [clearsky_radiation(d, latitude) for d in range(1, 366)]
+    emin, emax = min(energies), max(energies)
+    today = clearsky_radiation(when.timetuple().tm_yday, latitude)
+    light = (today - emin) / (emax - emin) if emax > emin else 1.0
     light = max(0.0, min(1.0, light))
     return winter + light * (args.fullvoltage - winter)
 
@@ -507,9 +525,11 @@ def loop(args):
                 if window_diffs and sample_count >= args.window_samples:
                     fullvoltage = effective_fullvoltage(args, forecast_factor)
                     soc = calc_soc(response[MEAN_V], args, fullvoltage)
+                    duty = soc_sleep_duty(soc, args.soc_sleep_gamma)
                     window_summary = {
                         'window_diffs': window_diffs,
                         'soc': soc,
+                        'duty': duty,
                         'fullvoltage': fullvoltage,
                     }
                     if forecast_enabled(args):
@@ -519,7 +539,7 @@ def loop(args):
                     log_json(args.log, window_summary, args.prometheus)
 
                     if args.sleepscript and (sample_count % args.window_samples == 0):
-                        duration = sleep_duty_seconds(soc, args.minsleepmins, args.maxsleepmins)
+                        duration = sleep_duty_seconds(duty, args.minsleepmins, args.maxsleepmins)
                         if duration:
                             send_command({'command': 'snooze', 'duration': duration}, args)
                             call_script(args.sleepscript)
@@ -610,6 +630,10 @@ def parse_args():
         '--forecast-url', default='',
         help='override the forecast provider base URL (mainly for testing)')
     parser.add_argument(
+        '--soc-sleep-gamma', default=1.0, type=float,
+        help='exponent bending the SOC->sleep curve; >1 sleeps harder at low '
+             'charge (e.g. 2.0 ~triples the sleep at 50%% SOC), 1.0 is linear')
+    parser.add_argument(
         '--minsleepmins', default=MIN_SLEEP_MINS, type=float,
         help='minimum time to sleep')
     parser.add_argument(
@@ -637,6 +661,7 @@ def parse_args():
     main_args = parser.parse_args()
     assert main_args.shutdownvoltage > main_args.deepsleepvoltage
     assert main_args.fullvoltage > main_args.shutdownvoltage
+    assert main_args.soc_sleep_gamma > 0
     if main_args.winter_fullvoltage:
         assert main_args.winter_fullvoltage > main_args.fullvoltage
     if forecast_enabled(main_args) and main_args.forecast_provider == 'metservice':

--- a/sleepypid/test_sleepypid.py
+++ b/sleepypid/test_sleepypid.py
@@ -10,8 +10,8 @@ from types import SimpleNamespace
 from prometheus_client import REGISTRY
 import sleepypid
 from sleepypid import (
-    get_uptime, mean_diff, sleep_duty_seconds, calc_soc, flatten_telemetry,
-    log_prometheus, call_script, parse_args, override_args,
+    get_uptime, mean_diff, sleep_duty_seconds, soc_sleep_duty, calc_soc,
+    flatten_telemetry, log_prometheus, call_script, parse_args, override_args,
     daylength_hours, seasonal_fullvoltage,
     extraterrestrial_radiation, clearsky_radiation, forecast_light_factor,
     parse_open_meteo, parse_metservice, effective_fullvoltage, update_forecast)
@@ -78,6 +78,23 @@ class SleepyidTestCase(unittest.TestCase):
         off.winter_fullvoltage = 0.0
         off.latitude = -41.1
         self.assertEqual(25.0, seasonal_fullvoltage(off, datetime.date(2026, 6, 21)))
+
+    def test_seasonal_fullvoltage_energy_ramp(self):
+        # energy-based interpolation runs sleepier (higher threshold) than the
+        # old daylength-linear curve through the dark half of the year, because
+        # winter's low sun angle cuts charge more than the shorter day implies.
+        args = namedtuple('args', ('fullvoltage', 'winter_fullvoltage', 'latitude'))
+        args.fullvoltage = 26.0
+        args.winter_fullvoltage = 27.0
+        args.latitude = -41.102223
+        when = datetime.date(2026, 5, 1)
+        energy = seasonal_fullvoltage(args, when)
+        # the equivalent daylength-linear threshold for the same day
+        daylengths = [daylength_hours(d, args.latitude) for d in range(1, 366)]
+        dmin, dmax = min(daylengths), max(daylengths)
+        light = (daylength_hours(when.timetuple().tm_yday, args.latitude) - dmin) / (dmax - dmin)
+        daylength = args.winter_fullvoltage + light * (args.fullvoltage - args.winter_fullvoltage)
+        self.assertGreater(energy, daylength)
 
     def test_extraterrestrial_radiation(self):
         # FAO-56 Example 8: 3 September (day 246) at 20 S -> Ra ~ 32.2 MJ/m^2
@@ -278,6 +295,24 @@ class SleepyidTestCase(unittest.TestCase):
             pct10_sleep_time += sleep_duty_seconds(10, 15, 1440)
         self.assertGreater(pct10_sleep_time, pct50_sleep_time)
         self.assertGreater(pct50_sleep_time, pct75_sleep_time)
+
+    def test_soc_sleep_duty(self):
+        # gamma 1.0 is the identity (original linear behaviour)
+        self.assertEqual(50, soc_sleep_duty(50, 1.0))
+        # endpoints are pinned regardless of gamma
+        self.assertEqual(0, soc_sleep_duty(0, 2.0))
+        self.assertEqual(100, soc_sleep_duty(100, 2.0))
+        # gamma>1 lowers the mid-range duty -> sleepier for the same SOC
+        self.assertAlmostEqual(25, soc_sleep_duty(50, 2.0), places=5)
+        self.assertLess(soc_sleep_duty(75, 2.0), 75)
+        # a lower duty yields more sleep through sleep_duty_seconds
+        bent = sum(sleep_duty_seconds(soc_sleep_duty(50, 2.0), 15, 1440)
+                   for _ in range(1000))
+        linear = sum(sleep_duty_seconds(50, 15, 1440) for _ in range(1000))
+        self.assertGreater(bent, linear)
+
+    def test_soc_sleep_gamma_arg(self):
+        self.assertEqual(1.0, parse_args().soc_sleep_gamma)
 
     def test_parse_args(self):
         with tempfile.TemporaryDirectory() as test_dir:


### PR DESCRIPTION
Makes the seasonal and forecast sleep adjustments more aggressive, per the two highest-leverage levers (P1 + P4).

## P1 — energy-based seasonal threshold
`seasonal_fullvoltage` now interpolates the considered-full threshold by today's **clear-sky solar energy** (`clearsky_radiation`, already in the module) instead of daylength. With the winter/summer endpoints pinned by `--winter-fullvoltage`/`--fullvoltage`, this reshapes the curve between them to run sleepier through the dark half — winter's low sun angle cuts daily charge more than the shorter day alone implies. (Modest in magnitude after endpoint normalization; mainly a correctness fix.)

## P4 — `--soc-sleep-gamma`
New `soc_sleep_duty` helper bends the SOC→sleep duty curve. The duty cycle equals SOC directly, which only sleeps hard once charge is already deep. A gamma `>1` lowers the mid-range duty (`2.0` ≈ triples sleep at 50% SOC) while pinning the 0%/100% endpoints. This stacks on top of the seasonal + forecast bumps and the raw SOC, acting directly on the sleep decision — the strongest aggression lever — without distorting the logged SOC. Default `1.0` is the original linear behavior. The applied duty is exported as `sleepypi_duty`.

Also: `--soc-sleep-gamma > 0` assertion, README updates (seasonal section + new "Sleep curve" section), and tests (`test_seasonal_fullvoltage_energy_ramp`, `test_soc_sleep_duty`, `test_soc_sleep_gamma_arg`).

## Testing
- `python sleepypid/test_sleepypid.py` — 25 pass
- `pylint sleepypid/sleepypid.py` — 10.00/10

Note: builds on the unmerged seasonal/forecast commits already on `ide`, so this PR includes them as prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)